### PR TITLE
Begin building unit tests for API

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleDirectories": ["node_modules", "src"],
+    "moduleNameMapper": {
+      "@alias/(.*)": "<rootDir>/src/$1"
+    }
   }
 }

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,13 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
+    const mockResponse = JSON.stringify({
+      name: 'GTFS API',
+      url: 'https://github.com/jurevans/transit-app-api/',
+    });
+
     it('should return "GTFS API"', () => {
-      expect(appController.getIndex()).toBe('GTFS API');
+      expect(appController.getIndex()).toEqual(mockResponse);
     });
   });
 });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { HealthController } from './health/health.controller';
 import { AuthMiddleware } from './middleware/auth.middleware';
 import { AuthModule } from './auth/auth.module';
 import { RealtimeModule } from './realtime/realtime.module';
+import authConfig from './config/auth.config';
 import gtfsRealtimeConfig from './config/gtfs.config';
 import redisConfig from './config/redis.config';
 import databaseConfig from './config/database.config';
@@ -29,7 +30,7 @@ import { CacheTtlSeconds } from './constants';
     ConfigModule.forRoot({
       isGlobal: true,
       cache: true,
-      load: [gtfsRealtimeConfig, redisConfig, databaseConfig],
+      load: [authConfig, gtfsRealtimeConfig, redisConfig, databaseConfig],
     }),
     CacheModule.registerAsync({
       useFactory: (configService: ConfigService): CacheModuleOptions => ({

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
+  const mockConfigService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class AuthService {
-  private apiKeys: string[] = process.env.API_KEYS.split(',');
+  constructor(private readonly configService: ConfigService) {}
 
-  validateApiKey(apiKey: string): string {
-    return this.apiKeys.find((key: string) => apiKey === key);
+  validateApiKey(apiKey: string): Promise<string> {
+    const { apiKeys } = this.configService.get('auth');
+    return apiKeys.find((key: string) => apiKey === key);
   }
 }

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 dotenv.config({ path: path.join(process.cwd(), '.env') });
 
-const { API_KEYS: auth } = process.env;
-const apiKeys = auth.split(',');
+const { API_KEYS: apiKeyString } = process.env;
+const apiKeys = apiKeyString.split(',');
 
 export default registerAs('auth', () => ({ apiKeys }));

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -1,0 +1,10 @@
+import { registerAs } from '@nestjs/config';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+dotenv.config({ path: path.join(process.cwd(), '.env') });
+
+const { API_KEYS: auth } = process.env;
+const apiKeys = auth.split(',');
+
+export default registerAs('auth', () => ({ apiKeys }));

--- a/src/config/auth.config.ts
+++ b/src/config/auth.config.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 dotenv.config({ path: path.join(process.cwd(), '.env') });
 
-const { API_KEYS: apiKeyString } = process.env;
-const apiKeys = apiKeyString.split(',');
+const { API_KEYS: apiKeysString } = process.env;
+const apiKeys = apiKeysString.split(',');
 
 export default registerAs('auth', () => ({ apiKeys }));

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,3 +18,5 @@ export enum Intervals {
   GTFS_TRIP_UPDATES = 30000,
   GTFS_ALERTS = 60000,
 }
+
+export const MAX_MINUTES = 60;

--- a/src/geo/geo.controller.spec.ts
+++ b/src/geo/geo.controller.spec.ts
@@ -1,12 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { GeoController } from './geo.controller';
+import { ShapesService } from './shapes.service';
+import { StopsService } from './stops.service';
 
 describe('GeoController', () => {
   let controller: GeoController;
 
+  const mockShapesService = {};
+  const mockStopsService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [GeoController],
+      providers: [
+        {
+          provide: ShapesService,
+          useValue: mockShapesService,
+        },
+        {
+          provide: StopsService,
+          useValue: mockStopsService,
+        },
+      ],
     }).compile();
 
     controller = module.get<GeoController>(GeoController);

--- a/src/geo/geo.controller.ts
+++ b/src/geo/geo.controller.ts
@@ -13,7 +13,8 @@ import { StopsService } from './stops.service';
 import { Stops } from 'entities/stops.entity';
 import {
   FeatureCollection,
-  LineString,
+  AggregatedFeatureCollection,
+  Geometry,
 } from 'geo/interfaces/geojson.interface';
 import { IShape } from './interfaces/shapes.interface';
 import { IStop } from './interfaces/stops.interface';
@@ -45,7 +46,7 @@ export class GeoController {
   find(
     @Param('feedIndex', ParseIntPipe) feedIndex: number,
     @Param('shapeId') shapeId: string,
-  ): Promise<LineString> {
+  ): Promise<Geometry> {
     return this.shapesService.find({ feedIndex, shapeId });
   }
 
@@ -56,7 +57,7 @@ export class GeoController {
     @Query('day') day?: string,
     @Query('geojson', new DefaultValuePipe(false), ParseBoolPipe)
     geojson?: boolean,
-  ): Promise<FeatureCollection | IStop[]> {
+  ): Promise<AggregatedFeatureCollection | IStop[]> {
     return this.stopsService.findAll({ feedIndex, day, geojson });
   }
 

--- a/src/geo/geo.controller.ts
+++ b/src/geo/geo.controller.ts
@@ -10,14 +10,14 @@ import {
 } from '@nestjs/common';
 import { ShapesService } from './shapes.service';
 import { StopsService } from './stops.service';
-import { Stops } from 'src/entities/stops.entity';
+import { Stops } from 'entities/stops.entity';
 import {
   FeatureCollection,
   LineString,
-} from 'src/geo/interfaces/geojson.interface';
+} from 'geo/interfaces/geojson.interface';
 import { IShape } from './interfaces/shapes.interface';
 import { IStop } from './interfaces/stops.interface';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 
 @Controller('geo')
 export class GeoController {

--- a/src/geo/geo.module.ts
+++ b/src/geo/geo.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { GeoController } from './geo.controller';
-import { ShapeGeoms } from 'src/entities/shapeGeoms.entity';
-import { Stops } from 'src/entities/stops.entity';
+import { ShapeGeoms } from 'entities/shapeGeoms.entity';
+import { Stops } from 'entities/stops.entity';
 import { StopsService } from './stops.service';
 import { ShapesService } from './shapes.service';
 

--- a/src/geo/interfaces/geojson.interface.ts
+++ b/src/geo/interfaces/geojson.interface.ts
@@ -3,11 +3,6 @@
  */
 export type Coordinate = [number, number];
 
-export interface LineString {
-  type: 'LineString';
-  coordinates: Coordinate[];
-}
-
 export interface Geometry {
   type: 'LineString' | 'Point' | 'Polygon'; // There are others, but will not likely be used here
   coordinates: Coordinate[];
@@ -17,16 +12,36 @@ export interface Feature {
   type: string;
   geometry: Geometry;
   properties: {
+    id: string;
     name: string;
+    longName?: string;
     color?: string;
     description?: string;
     url?: string;
-    id?: string;
     routeid?: string;
+    length?: number;
   };
 }
 
 export interface FeatureCollection {
   type: string;
   features: Feature[];
+}
+
+// TODO: Aggregation will be removed from the query in the future:
+export interface AggregatedPointFeature extends Feature {
+  properties: {
+    id: string;
+    name: string;
+    routeIds: string;
+    routeNames: string;
+    routeLongNames: string;
+    routeColors: string;
+    routeUrls: string;
+  };
+}
+
+// TODO: Aggregation will be removed from the query in the future:
+export interface AggregatedFeatureCollection extends FeatureCollection {
+  features: AggregatedPointFeature[];
 }

--- a/src/geo/interfaces/stops.interface.ts
+++ b/src/geo/interfaces/stops.interface.ts
@@ -4,5 +4,5 @@ export interface IStop {
   routeLongNames: string;
   routeColors: string | null;
   name: string;
-  the_geom: string;
+  theGeom: string;
 }

--- a/src/geo/shapes.service.spec.ts
+++ b/src/geo/shapes.service.spec.ts
@@ -1,12 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ShapesService } from './shapes.service';
+import { ShapeGeoms } from 'entities/shapeGeoms.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('ShapesService', () => {
   let service: ShapesService;
 
+  const mockShapesRepository = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ShapesService],
+      providers: [
+        ShapesService,
+        {
+          provide: getRepositoryToken(ShapeGeoms),
+          useValue: mockShapesRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<ShapesService>(ShapesService);

--- a/src/geo/shapes.service.ts
+++ b/src/geo/shapes.service.ts
@@ -3,10 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { getManager, Repository } from 'typeorm';
 import { ShapeGeoms } from 'entities/shapeGeoms.entity';
 import { getCurrentDay } from 'util/';
-import {
-  FeatureCollection,
-  LineString,
-} from 'geo/interfaces/geojson.interface';
+import { FeatureCollection, Geometry } from 'geo/interfaces/geojson.interface';
 import { IShape } from './interfaces/shapes.interface';
 
 @Injectable()
@@ -16,10 +13,7 @@ export class ShapesService {
     private shapeGeomsRepository: Repository<ShapeGeoms>,
   ) {}
 
-  async find(props: {
-    feedIndex: number;
-    shapeId: string;
-  }): Promise<LineString> {
+  async find(props: { feedIndex: number; shapeId: string }): Promise<Geometry> {
     const { feedIndex, shapeId } = props;
     const shapeData = await this.shapeGeomsRepository
       .createQueryBuilder('shapeGeoms')
@@ -73,7 +67,7 @@ export class ShapesService {
       )
       FROM (
         ${queryRoutesWithShapes}
-      ) AS t("shape_len", "routeId", "name", "longName", "color", "description", "url", "id", "geom");
+      ) AS t("length", "routeId", "name", "longName", "color", "description", "url", "id", "geom");
     `;
 
     // For any routes missing Shapes, generate LineString geometry

--- a/src/geo/shapes.service.ts
+++ b/src/geo/shapes.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { getManager, Repository } from 'typeorm';
-import { ShapeGeoms } from 'src/entities/shapeGeoms.entity';
-import { getCurrentDay } from 'src/util';
+import { ShapeGeoms } from 'entities/shapeGeoms.entity';
+import { getCurrentDay } from 'util/';
 import {
   FeatureCollection,
   LineString,
-} from 'src/geo/interfaces/geojson.interface';
+} from 'geo/interfaces/geojson.interface';
 import { IShape } from './interfaces/shapes.interface';
 
 @Injectable()

--- a/src/geo/stops.service.spec.ts
+++ b/src/geo/stops.service.spec.ts
@@ -1,12 +1,22 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { StopsService } from './stops.service';
+import { Stops } from 'entities/stops.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('StopsService', () => {
   let service: StopsService;
 
+  const mockStopsRepository = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StopsService],
+      providers: [
+        StopsService,
+        {
+          provide: getRepositoryToken(Stops),
+          useValue: mockStopsRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<StopsService>(StopsService);

--- a/src/geo/stops.service.ts
+++ b/src/geo/stops.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { getManager, Repository } from 'typeorm';
-import { Stops } from 'src/entities/stops.entity';
-import { getCurrentDay } from 'src/util';
+import { Stops } from 'entities/stops.entity';
+import { getCurrentDay } from 'util/';
 
 @Injectable()
 export class StopsService {

--- a/src/geo/stops.service.ts
+++ b/src/geo/stops.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { getManager, Repository } from 'typeorm';
 import { Stops } from 'entities/stops.entity';
 import { getCurrentDay } from 'util/';
+import { AggregatedFeatureCollection } from './interfaces/geojson.interface';
+import { IStop } from './interfaces/stops.interface';
 
 @Injectable()
 export class StopsService {
@@ -11,7 +13,11 @@ export class StopsService {
     private stopsRepository: Repository<Stops>,
   ) {}
 
-  async findAll(props: { feedIndex: number; day?: string; geojson?: boolean }) {
+  async findAll(props: {
+    feedIndex: number;
+    day?: string;
+    geojson?: boolean;
+  }): Promise<AggregatedFeatureCollection | IStop[]> {
     const { feedIndex, day, geojson } = props;
     const manager = getManager();
     const today = day || getCurrentDay();

--- a/src/gtfs/agency/agency.controller.spec.ts
+++ b/src/gtfs/agency/agency.controller.spec.ts
@@ -6,7 +6,12 @@ import { IAgency } from '../interfaces/agency.interface';
 describe('AgencyController', () => {
   let controller: AgencyController;
 
-  const feedIndices = ['1'];
+  const mockAgencyService = {
+    findAll: jest.fn().mockImplementation((): Promise<IAgency[]> => {
+      return Promise.resolve([mockAgency]);
+    }),
+  };
+
   const mockAgency: IAgency = {
     feedIndex: 1,
     agencyId: 'MTA NYCT',
@@ -17,19 +22,13 @@ describe('AgencyController', () => {
     agencyUrl: 'http://www.mta.info',
   };
 
-  const MockAgencyService = {
-    findAll: jest.fn(() => {
-      return mockAgency;
-    }),
-  };
-
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AgencyController],
       providers: [AgencyService],
     })
       .overrideProvider(AgencyService)
-      .useValue(MockAgencyService)
+      .useValue(mockAgencyService)
       .compile();
 
     controller = module.get<AgencyController>(AgencyController);
@@ -39,7 +38,21 @@ describe('AgencyController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should return a Agency', () => {
-    expect(controller.findOne(feedIndices)).toEqual(mockAgency);
+  it('should return a Agency', async () => {
+    const feedIndices = ['1'];
+
+    expect(await controller.findOne(feedIndices)).toEqual([
+      {
+        feedIndex: 1,
+        agencyId: expect.any(String),
+        agencyLang: expect.any(String),
+        agencyName: expect.any(String),
+        agencyPhone: expect.any(String),
+        agencyTimezone: expect.any(String),
+        agencyUrl: expect.any(String),
+      },
+    ]);
+
+    expect(mockAgencyService.findAll).toHaveBeenCalledWith({ feedIndices });
   });
 });

--- a/src/gtfs/agency/agency.controller.spec.ts
+++ b/src/gtfs/agency/agency.controller.spec.ts
@@ -1,18 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AgencyController } from './agency.controller';
+import { AgencyService } from './agency.service';
+import { IAgency } from '../interfaces/agency.interface';
 
 describe('AgencyController', () => {
   let controller: AgencyController;
 
+  const feedIndices = ['1'];
+  const mockAgency: IAgency = {
+    feedIndex: 1,
+    agencyId: 'MTA NYCT',
+    agencyLang: 'en',
+    agencyName: 'MTA New York City Transit',
+    agencyPhone: '718-330-1234',
+    agencyTimezone: 'America/New_York',
+    agencyUrl: 'http://www.mta.info',
+  };
+
+  const MockAgencyService = {
+    findAll: jest.fn(() => {
+      return mockAgency;
+    }),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AgencyController],
-    }).compile();
+      providers: [AgencyService],
+    })
+      .overrideProvider(AgencyService)
+      .useValue(MockAgencyService)
+      .compile();
 
     controller = module.get<AgencyController>(AgencyController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return a Agency', () => {
+    expect(controller.findOne(feedIndices)).toEqual(mockAgency);
   });
 });

--- a/src/gtfs/agency/agency.controller.spec.ts
+++ b/src/gtfs/agency/agency.controller.spec.ts
@@ -6,8 +6,16 @@ import { IAgency } from '../interfaces/agency.interface';
 describe('AgencyController', () => {
   let controller: AgencyController;
 
+  type Props = {
+    feedIndices: string[];
+  };
+
   const mockAgencyService = {
-    findAll: jest.fn().mockImplementation((): Promise<IAgency[]> => {
+    find: jest.fn().mockImplementation((props: Props): Promise<IAgency[]> => {
+      const { feedIndices } = props;
+      if (!feedIndices || feedIndices.length === 0) {
+        return Promise.reject();
+      }
       return Promise.resolve([mockAgency]);
     }),
   };
@@ -40,8 +48,11 @@ describe('AgencyController', () => {
 
   it('should return a Agency', async () => {
     const feedIndices = ['1'];
+    const props: Props = {
+      feedIndices,
+    };
 
-    expect(await controller.findOne(feedIndices)).toEqual([
+    expect(await controller.find(feedIndices)).toEqual([
       {
         feedIndex: 1,
         agencyId: expect.any(String),
@@ -53,6 +64,6 @@ describe('AgencyController', () => {
       },
     ]);
 
-    expect(mockAgencyService.findAll).toHaveBeenCalledWith({ feedIndices });
+    expect(mockAgencyService.find).toHaveBeenCalledWith(props);
   });
 });

--- a/src/gtfs/agency/agency.controller.ts
+++ b/src/gtfs/agency/agency.controller.ts
@@ -15,9 +15,9 @@ export class AgencyController {
 
   @Get('feeds/:feedIndexList')
   @CacheTTL(CacheTtlSeconds.ONE_DAY)
-  findOne(
+  find(
     @Param('feedIndexList', ParseArrayPipe) feedIndices: string[],
   ): Promise<IAgency[]> {
-    return this.agencyService.findAll({ feedIndices });
+    return this.agencyService.find({ feedIndices });
   }
 }

--- a/src/gtfs/agency/agency.controller.ts
+++ b/src/gtfs/agency/agency.controller.ts
@@ -6,7 +6,7 @@ import {
   ParseArrayPipe,
 } from '@nestjs/common';
 import { AgencyService } from './agency.service';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 import { IAgency } from '../interfaces/agency.interface';
 
 @Controller('agency')

--- a/src/gtfs/agency/agency.service.spec.ts
+++ b/src/gtfs/agency/agency.service.spec.ts
@@ -1,12 +1,37 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Agency } from 'entities/agency.entity';
+import { IAgency } from 'gtfs/interfaces/agency.interface';
 import { AgencyService } from './agency.service';
 
 describe('AgencyService', () => {
   let service: AgencyService;
 
+  const mockAgencyRepository = {
+    find: jest.fn().mockImplementation((): Promise<IAgency[]> => {
+      return Promise.resolve([mockAgency]);
+    }),
+  };
+
+  const mockAgency: IAgency = {
+    feedIndex: 1,
+    agencyId: 'MTA NYCT',
+    agencyLang: 'en',
+    agencyName: 'MTA New York City Transit',
+    agencyPhone: '718-330-1234',
+    agencyTimezone: 'America/New_York',
+    agencyUrl: 'http://www.mta.info',
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AgencyService],
+      providers: [
+        AgencyService,
+        {
+          provide: getRepositoryToken(Agency),
+          useValue: mockAgencyRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<AgencyService>(AgencyService);
@@ -14,5 +39,23 @@ describe('AgencyService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should return an array of Agencies', async () => {
+    const feedIndicesProps = {
+      feedIndices: ['1'],
+    };
+
+    expect(await service.findAll(feedIndicesProps)).toEqual([
+      {
+        feedIndex: 1,
+        agencyId: expect.any(String),
+        agencyLang: expect.any(String),
+        agencyName: expect.any(String),
+        agencyPhone: expect.any(String),
+        agencyTimezone: expect.any(String),
+        agencyUrl: expect.any(String),
+      },
+    ]);
   });
 });

--- a/src/gtfs/agency/agency.service.spec.ts
+++ b/src/gtfs/agency/agency.service.spec.ts
@@ -7,6 +7,10 @@ import { AgencyService } from './agency.service';
 describe('AgencyService', () => {
   let service: AgencyService;
 
+  type Props = {
+    feedIndices: string[];
+  };
+
   const mockAgencyRepository = {
     find: jest.fn().mockImplementation((): Promise<IAgency[]> => {
       return Promise.resolve([mockAgency]);
@@ -42,11 +46,11 @@ describe('AgencyService', () => {
   });
 
   it('should return an array of Agencies', async () => {
-    const feedIndicesProps = {
+    const feedIndicesProps: Props = {
       feedIndices: ['1'],
     };
 
-    expect(await service.findAll(feedIndicesProps)).toEqual([
+    expect(await service.find(feedIndicesProps)).toEqual([
       {
         feedIndex: 1,
         agencyId: expect.any(String),

--- a/src/gtfs/agency/agency.service.ts
+++ b/src/gtfs/agency/agency.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import { Agency } from 'src/entities/agency.entity';
+import { Agency } from 'entities/agency.entity';
 import { IAgency } from '../interfaces/agency.interface';
 
 @Injectable()

--- a/src/gtfs/agency/agency.service.ts
+++ b/src/gtfs/agency/agency.service.ts
@@ -11,7 +11,7 @@ export class AgencyService {
     private agencyRepository: Repository<Agency>,
   ) {}
 
-  findAll(props: { feedIndices: string[] }): Promise<IAgency[]> {
+  find(props: { feedIndices: string[] }): Promise<IAgency[]> {
     const { feedIndices } = props;
     return this.agencyRepository.find({
       select: [

--- a/src/gtfs/feed/feed.controller.spec.ts
+++ b/src/gtfs/feed/feed.controller.spec.ts
@@ -1,13 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FeedController } from './feed.controller';
+import { FeedService } from './feed.service';
 
 describe('FeedController', () => {
   let controller: FeedController;
 
+  const mockFeedService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FeedController],
-    }).compile();
+      providers: [FeedService],
+    })
+      .overrideProvider(FeedService)
+      .useValue(mockFeedService)
+      .compile();
 
     controller = module.get<FeedController>(FeedController);
   });

--- a/src/gtfs/feed/feed.controller.spec.ts
+++ b/src/gtfs/feed/feed.controller.spec.ts
@@ -1,11 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FeedController } from './feed.controller';
 import { FeedService } from './feed.service';
+import { IStaticFeed } from '../interfaces/feed.interface';
 
 describe('FeedController', () => {
   let controller: FeedController;
 
-  const mockFeedService = {};
+  const mockFeedService = {
+    findOne: jest.fn().mockImplementation((): Promise<IStaticFeed> => {
+      return Promise.resolve(mockFeed);
+    }),
+    findAll: jest.fn().mockImplementation((): Promise<IStaticFeed[]> => {
+      return Promise.resolve([mockFeed]);
+    }),
+  };
+
+  const mockFeed: IStaticFeed = {
+    feedIndex: 1,
+    feedStartDate: '2021-06-27',
+    feedEndDate: '2021-07-24',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -21,5 +35,29 @@ describe('FeedController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return a Feed', async () => {
+    const feedIndex = 1;
+
+    expect(await controller.findOne(feedIndex)).toEqual({
+      feedIndex: 1,
+      feedStartDate: expect.any(String),
+      feedEndDate: expect.any(String),
+    });
+
+    expect(mockFeedService.findOne).toHaveBeenCalledWith({ feedIndex });
+  });
+
+  it('should return all Feeds', async () => {
+    expect(await controller.findAll()).toEqual([
+      {
+        feedIndex: 1,
+        feedStartDate: expect.any(String),
+        feedEndDate: expect.any(String),
+      },
+    ]);
+
+    expect(mockFeedService.findAll).toHaveBeenCalledWith();
   });
 });

--- a/src/gtfs/feed/feed.controller.spec.ts
+++ b/src/gtfs/feed/feed.controller.spec.ts
@@ -6,10 +6,20 @@ import { IStaticFeed } from '../interfaces/feed.interface';
 describe('FeedController', () => {
   let controller: FeedController;
 
+  type Props = {
+    feedIndex: number;
+  };
+
   const mockFeedService = {
-    findOne: jest.fn().mockImplementation((): Promise<IStaticFeed> => {
-      return Promise.resolve(mockFeed);
-    }),
+    findOne: jest
+      .fn()
+      .mockImplementation((props: Props): Promise<IStaticFeed> => {
+        const { feedIndex } = props;
+        if (!feedIndex) {
+          return Promise.reject();
+        }
+        return Promise.resolve(mockFeed);
+      }),
     findAll: jest.fn().mockImplementation((): Promise<IStaticFeed[]> => {
       return Promise.resolve([mockFeed]);
     }),
@@ -39,6 +49,7 @@ describe('FeedController', () => {
 
   it('should return a Feed', async () => {
     const feedIndex = 1;
+    const props: Props = { feedIndex };
 
     expect(await controller.findOne(feedIndex)).toEqual({
       feedIndex: 1,
@@ -46,7 +57,7 @@ describe('FeedController', () => {
       feedEndDate: expect.any(String),
     });
 
-    expect(mockFeedService.findOne).toHaveBeenCalledWith({ feedIndex });
+    expect(mockFeedService.findOne).toHaveBeenCalledWith(props);
   });
 
   it('should return all Feeds', async () => {

--- a/src/gtfs/feed/feed.controller.ts
+++ b/src/gtfs/feed/feed.controller.ts
@@ -1,6 +1,6 @@
 import { CacheTTL, Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { FeedService } from './feed.service';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 import { IStaticFeed } from '../interfaces/feed.interface';
 
 @Controller('feed')

--- a/src/gtfs/feed/feed.service.spec.ts
+++ b/src/gtfs/feed/feed.service.spec.ts
@@ -2,11 +2,25 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { FeedService } from './feed.service';
 import { FeedInfo } from 'entities/feedInfo.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { IStaticFeed } from '../interfaces/feed.interface';
 
 describe('FeedService', () => {
   let service: FeedService;
 
-  const mockFeedRepository = {};
+  const mockFeedRepository = {
+    findOneOrFail: jest.fn().mockImplementation((): Promise<IStaticFeed> => {
+      return Promise.resolve(mockFeed);
+    }),
+    find: jest.fn().mockImplementation((): Promise<IStaticFeed[]> => {
+      return Promise.resolve([mockFeed]);
+    }),
+  };
+
+  const mockFeed: IStaticFeed = {
+    feedIndex: 1,
+    feedStartDate: '2021-06-27',
+    feedEndDate: '2021-07-24',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -24,5 +38,27 @@ describe('FeedService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should return an array of Feeds', async () => {
+    expect(await service.findAll()).toEqual([
+      {
+        feedIndex: 1,
+        feedStartDate: expect.any(String),
+        feedEndDate: expect.any(String),
+      },
+    ]);
+  });
+
+  it('should return a Feed', async () => {
+    const feedIndexProps = {
+      feedIndex: 1,
+    };
+
+    expect(await service.findOne(feedIndexProps)).toEqual({
+      feedIndex: 1,
+      feedStartDate: expect.any(String),
+      feedEndDate: expect.any(String),
+    });
   });
 });

--- a/src/gtfs/feed/feed.service.ts
+++ b/src/gtfs/feed/feed.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { FeedInfo } from 'src/entities/feedInfo.entity';
+import { FeedInfo } from 'entities/feedInfo.entity';
 import { IStaticFeed } from '../interfaces/feed.interface';
 
 @Injectable()

--- a/src/gtfs/gtfs.module.ts
+++ b/src/gtfs/gtfs.module.ts
@@ -8,11 +8,11 @@ import { LocationService } from './location/location.service';
 import { LocationController } from './location/location.controller';
 import { FeedService } from './feed/feed.service';
 import { FeedController } from './feed/feed.controller';
-import { Routes } from 'src/entities/routes.entity';
-import { Trips } from 'src/entities/trips.entity';
-import { Agency } from 'src/entities/agency.entity';
-import { FeedInfo } from 'src/entities/feedInfo.entity';
-import { Stops } from 'src/entities/stops.entity';
+import { Routes } from 'entities/routes.entity';
+import { Trips } from 'entities/trips.entity';
+import { Agency } from 'entities/agency.entity';
+import { FeedInfo } from 'entities/feedInfo.entity';
+import { Stops } from 'entities/stops.entity';
 import { StopsService } from './stops/stops.service';
 import { StopsController } from './stops/stops.controller';
 

--- a/src/gtfs/interfaces/stops.interface.ts
+++ b/src/gtfs/interfaces/stops.interface.ts
@@ -4,7 +4,7 @@ export interface IStop {
   headsign: string;
   tripId: string;
   routeId: string;
-  direction_id: number;
+  directionId: number;
   time: number;
 }
 

--- a/src/gtfs/location/location.controller.spec.ts
+++ b/src/gtfs/location/location.controller.spec.ts
@@ -1,13 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocationController } from './location.controller';
+import { LocationService } from './location.service';
 
 describe('LocationController', () => {
   let controller: LocationController;
 
+  const mockLocationService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LocationController],
-    }).compile();
+      providers: [LocationService],
+    })
+      .overrideProvider(LocationService)
+      .useValue(mockLocationService)
+      .compile();
 
     controller = module.get<LocationController>(LocationController);
   });

--- a/src/gtfs/location/location.controller.spec.ts
+++ b/src/gtfs/location/location.controller.spec.ts
@@ -1,11 +1,31 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocationController } from './location.controller';
 import { LocationService } from './location.service';
+import { ILocation } from '../interfaces/location.interface';
 
 describe('LocationController', () => {
   let controller: LocationController;
 
-  const mockLocationService = {};
+  type Props = {
+    feedIndex: number;
+  };
+
+  const mockLocationService = {
+    findLocation: jest
+      .fn()
+      .mockImplementation((props: Props): Promise<ILocation> => {
+        const { feedIndex } = props;
+        if (!feedIndex) {
+          return Promise.reject();
+        }
+        return Promise.resolve(mockLocation);
+      }),
+  };
+
+  const mockLocation = {
+    longitude: -73.94594865587045,
+    latitude: 40.7227534777328,
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -21,5 +41,18 @@ describe('LocationController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should return a Feed', async () => {
+    const feedIndex = 1;
+
+    expect(await controller.findLocation(feedIndex)).toEqual({
+      longitude: expect.any(Number),
+      latitude: expect.any(Number),
+    });
+
+    expect(mockLocationService.findLocation).toHaveBeenCalledWith({
+      feedIndex,
+    });
   });
 });

--- a/src/gtfs/location/location.controller.spec.ts
+++ b/src/gtfs/location/location.controller.spec.ts
@@ -45,14 +45,13 @@ describe('LocationController', () => {
 
   it('should return a Feed', async () => {
     const feedIndex = 1;
+    const props: Props = { feedIndex };
 
     expect(await controller.findLocation(feedIndex)).toEqual({
       longitude: expect.any(Number),
       latitude: expect.any(Number),
     });
 
-    expect(mockLocationService.findLocation).toHaveBeenCalledWith({
-      feedIndex,
-    });
+    expect(mockLocationService.findLocation).toHaveBeenCalledWith(props);
   });
 });

--- a/src/gtfs/location/location.controller.ts
+++ b/src/gtfs/location/location.controller.ts
@@ -1,5 +1,5 @@
 import { CacheTTL, Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 import { ILocation } from '../interfaces/location.interface';
 import { LocationService } from './location.service';
 

--- a/src/gtfs/location/location.service.spec.ts
+++ b/src/gtfs/location/location.service.spec.ts
@@ -1,12 +1,35 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocationService } from './location.service';
+import { ILocation } from '../interfaces/location.interface';
+import { EntityManager } from 'typeorm';
 
 describe('LocationService', () => {
   let service: LocationService;
 
+  type Props = {
+    feedIndex: number;
+  };
+
+  const mockEntityManager = {
+    query: jest.fn().mockImplementation(async (): Promise<ILocation[]> => {
+      return Promise.resolve([mockLocation]);
+    }),
+  };
+
+  const mockLocation: ILocation = {
+    longitude: -73.94594865587045,
+    latitude: 40.7227534777328,
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LocationService],
+      providers: [
+        LocationService,
+        {
+          provide: EntityManager,
+          useValue: mockEntityManager,
+        },
+      ],
     }).compile();
 
     service = module.get<LocationService>(LocationService);
@@ -14,5 +37,16 @@ describe('LocationService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should return a location', async () => {
+    const props: Props = {
+      feedIndex: 1,
+    };
+
+    expect(await service.findLocation(props)).toEqual({
+      longitude: expect.any(Number),
+      latitude: expect.any(Number),
+    });
   });
 });

--- a/src/gtfs/location/location.service.ts
+++ b/src/gtfs/location/location.service.ts
@@ -1,14 +1,19 @@
-import { getManager } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 import { ILocation } from '../interfaces/location.interface';
 
+@Injectable()
 export class LocationService {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {}
+  constructor(
+    @InjectEntityManager()
+    private readonly entityManager: EntityManager,
+  ) {}
 
   async findLocation(params: { feedIndex: number }): Promise<ILocation> {
     const { feedIndex } = params;
-    const manager = getManager();
-    const locationResults = await manager.query(`
+
+    const locationResults = await this.entityManager.query(`
       WITH centroid AS (
         SELECT ST_Centroid(geom) center
         FROM (SELECT ST_Multi(ST_Union(the_geom))::geometry(MultiPoint, 4326) AS geom
@@ -20,11 +25,7 @@ export class LocationService {
     `);
 
     if (locationResults.length > 0) {
-      const { longitude, latitude } = locationResults[0];
-      return {
-        longitude,
-        latitude,
-      };
+      return locationResults[0];
     }
   }
 }

--- a/src/gtfs/routes/routes.controller.spec.ts
+++ b/src/gtfs/routes/routes.controller.spec.ts
@@ -1,13 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoutesController } from './routes.controller';
+import { RoutesService } from './routes.service';
 
 describe('RoutesController', () => {
   let controller: RoutesController;
 
+  const mockRoutesService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RoutesController],
-    }).compile();
+      providers: [RoutesService],
+    })
+      .overrideProvider(RoutesService)
+      .useValue(mockRoutesService)
+      .compile();
 
     controller = module.get<RoutesController>(RoutesController);
   });

--- a/src/gtfs/routes/routes.controller.ts
+++ b/src/gtfs/routes/routes.controller.ts
@@ -6,11 +6,11 @@ import {
   ParseIntPipe,
   Query,
 } from '@nestjs/common';
-import { IRoute } from 'src/gtfs/interfaces/routes.interface';
-import { Routes } from 'src/entities/routes.entity';
-import { Trips } from 'src/entities/trips.entity';
+import { IRoute } from 'gtfs/interfaces/routes.interface';
+import { Routes } from 'entities/routes.entity';
+import { Trips } from 'entities/trips.entity';
 import { RoutesService } from './routes.service';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 
 @Controller('routes')
 export class RoutesController {

--- a/src/gtfs/routes/routes.service.spec.ts
+++ b/src/gtfs/routes/routes.service.spec.ts
@@ -1,12 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { RoutesService } from './routes.service';
+import { Routes } from 'entities/routes.entity';
+import { Trips } from 'entities/trips.entity';
 
 describe('RoutesService', () => {
   let service: RoutesService;
 
+  const mockRoutesRepository = {};
+  const mockTripsRepository = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RoutesService],
+      providers: [
+        RoutesService,
+        {
+          provide: getRepositoryToken(Routes),
+          useValue: mockRoutesRepository,
+        },
+        {
+          provide: getRepositoryToken(Trips),
+          useValue: mockTripsRepository,
+        },
+      ],
     }).compile();
 
     service = module.get<RoutesService>(RoutesService);

--- a/src/gtfs/routes/routes.service.ts
+++ b/src/gtfs/routes/routes.service.ts
@@ -66,7 +66,11 @@ export class RoutesService {
     return routes;
   }
 
-  async findTrips(props: { feedIndex: number; routeId: string; day: string }) {
+  async findTrips(props: {
+    feedIndex: number;
+    routeId: string;
+    day: string;
+  }): Promise<Trips[]> {
     const { feedIndex, routeId, day } = props;
     const today = day || getCurrentDay();
 
@@ -81,7 +85,7 @@ export class RoutesService {
     return trips;
   }
 
-  async findRouteIds(props: { feedIndex: number }): Promise<any> {
+  async findRouteIds(props: { feedIndex: number }): Promise<string[]> {
     const { feedIndex } = props;
     const routeIdsResults = await this.routesRepository.find({
       select: ['routeId'],

--- a/src/gtfs/routes/routes.service.ts
+++ b/src/gtfs/routes/routes.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Routes } from 'src/entities/routes.entity';
-import { Trips } from 'src/entities/trips.entity';
-import { getCurrentDay } from 'src/util';
-import { IRoute } from 'src/gtfs/interfaces/routes.interface';
+import { Routes } from 'entities/routes.entity';
+import { Trips } from 'entities/trips.entity';
+import { getCurrentDay } from 'util/';
+import { IRoute } from 'gtfs/interfaces/routes.interface';
 
 @Injectable()
 export class RoutesService {

--- a/src/gtfs/stops/stops.controller.spec.ts
+++ b/src/gtfs/stops/stops.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { StopsController } from './stops.controller';
+import { StopsService } from './stops.service';
+
+describe('StopsController', () => {
+  let controller: StopsController;
+
+  const mockStopsService = {};
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [StopsController],
+      providers: [StopsService],
+    })
+      .overrideProvider(StopsService)
+      .useValue(mockStopsService)
+      .compile();
+
+    controller = module.get<StopsController>(StopsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/gtfs/stops/stops.controller.ts
+++ b/src/gtfs/stops/stops.controller.ts
@@ -1,5 +1,5 @@
 import { CacheTTL, Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 import { IParentStation } from '../interfaces/stops.interface';
 import { StopsService } from './stops.service';
 

--- a/src/gtfs/stops/stops.service.spec.ts
+++ b/src/gtfs/stops/stops.service.spec.ts
@@ -1,25 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { FeedService } from './feed.service';
-import { FeedInfo } from 'entities/feedInfo.entity';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { StopsService } from './stops.service';
+import { Stops } from 'entities/stops.entity';
 
-describe('FeedService', () => {
-  let service: FeedService;
+describe('StopsService', () => {
+  let service: StopsService;
 
-  const mockFeedRepository = {};
+  const mockStopsRepository = {};
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        FeedService,
+        StopsService,
         {
-          provide: getRepositoryToken(FeedInfo),
-          useValue: mockFeedRepository,
+          provide: getRepositoryToken(Stops),
+          useValue: mockStopsRepository,
         },
       ],
     }).compile();
 
-    service = module.get<FeedService>(FeedService);
+    service = module.get<StopsService>(StopsService);
   });
 
   it('should be defined', () => {

--- a/src/gtfs/stops/stops.service.ts
+++ b/src/gtfs/stops/stops.service.ts
@@ -22,7 +22,7 @@ export class StopsService {
         t.trip_headsign AS "headsign",
         t.trip_id AS "tripId",
         t.route_id AS "routeId",
-        t.direction_id,
+        t.direction_id AS "directionId",
         EXTRACT(epoch FROM st.arrival_time) AS "time"
       FROM stops s
       INNER JOIN

--- a/src/gtfs/stops/stops.service.ts
+++ b/src/gtfs/stops/stops.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { getManager, Repository } from 'typeorm';
-import { Stops } from 'src/entities/stops.entity';
+import { Stops } from 'entities/stops.entity';
 import { IParentStation } from '../interfaces/stops.interface';
 
 @Injectable()

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,12 +1,26 @@
+import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
 
 describe('HealthController', () => {
   let controller: HealthController;
 
+  const mockHealthCheckService = {};
+  const mockTypeOrmHealthIndicator = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HealthController],
+      providers: [
+        {
+          provide: HealthCheckService,
+          useValue: mockHealthCheckService,
+        },
+        {
+          provide: TypeOrmHealthIndicator,
+          useValue: mockTypeOrmHealthIndicator,
+        },
+      ],
     }).compile();
 
     controller = module.get<HealthController>(HealthController);

--- a/src/realtime/alerts/alerts.service.spec.ts
+++ b/src/realtime/alerts/alerts.service.spec.ts
@@ -1,12 +1,33 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { AlertsService } from './alerts.service';
+import { FeedService } from '../feed/feed.service';
 
 describe('AlertsService', () => {
   let service: AlertsService;
 
+  const mockFeedService = {};
+  const mockConfigService = {};
+  const mockCacheManager = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AlertsService],
+      providers: [
+        AlertsService,
+        {
+          provide: FeedService,
+          useValue: mockFeedService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+      ],
     }).compile();
 
     service = module.get<AlertsService>(AlertsService);

--- a/src/realtime/alerts/alerts.service.ts
+++ b/src/realtime/alerts/alerts.service.ts
@@ -2,8 +2,8 @@ import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cache } from 'cache-manager';
 import { FeedService } from '../feed/feed.service';
-import { CacheKeyPrefix, CacheTtlSeconds } from 'src/constants';
-import { formatCacheKey, getConfigByFeedIndex } from 'src/util';
+import { CacheKeyPrefix, CacheTtlSeconds } from 'constants/';
+import { formatCacheKey, getConfigByFeedIndex } from 'util/';
 import { IAlerts } from '../interfaces/alerts.interface';
 import { IRealtimeFeed } from '../interfaces/feed.interface';
 

--- a/src/realtime/feed/feed.service.spec.ts
+++ b/src/realtime/feed/feed.service.spec.ts
@@ -1,12 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { FeedService } from './feed.service';
 
 describe('FeedService', () => {
   let service: FeedService;
 
+  const mockConfigService = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FeedService],
+      providers: [
+        FeedService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
     }).compile();
 
     service = module.get<FeedService>(FeedService);

--- a/src/realtime/feed/feed.service.ts
+++ b/src/realtime/feed/feed.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import fetch from 'node-fetch';
-import * as GTFS from 'proto/gtfs-realtime';
-import { getConfigByFeedIndex } from 'src/util';
+import * as GTFS from '../../../proto/gtfs-realtime';
+import { getConfigByFeedIndex } from 'util/';
 import { IRealtimeFeed } from '../interfaces/feed.interface';
 
 @Injectable()

--- a/src/realtime/realtime.controller.ts
+++ b/src/realtime/realtime.controller.ts
@@ -8,7 +8,7 @@ import {
 } from '@nestjs/common';
 import { AlertsService } from './alerts/alerts.service';
 import { TripUpdatesService } from './trip-updates/trip-updates.service';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 
 @Controller('realtime')
 export class RealtimeController {

--- a/src/realtime/realtime.gateway.spec.ts
+++ b/src/realtime/realtime.gateway.spec.ts
@@ -1,12 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RealtimeGateway } from './realtime.gateway';
+import { AlertsService } from './alerts/alerts.service';
+import { TripUpdatesService } from './trip-updates/trip-updates.service';
+import { StationsService } from './stations/stations.service';
+import { SchedulerRegistry } from '@nestjs/schedule';
 
 describe('RealtimeGateway', () => {
   let gateway: RealtimeGateway;
 
+  const mockAlertsService = {};
+  const mockTripUpdatesService = {};
+  const mockStationsService = {};
+  const mockSchedulerRegistry = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RealtimeGateway],
+      providers: [
+        RealtimeGateway,
+        {
+          provide: AlertsService,
+          useValue: mockAlertsService,
+        },
+        {
+          provide: TripUpdatesService,
+          useValue: mockTripUpdatesService,
+        },
+        {
+          provide: StationsService,
+          useValue: mockStationsService,
+        },
+        {
+          provide: SchedulerRegistry,
+          useValue: mockSchedulerRegistry,
+        },
+      ],
     }).compile();
 
     gateway = module.get<RealtimeGateway>(RealtimeGateway);

--- a/src/realtime/realtime.gateway.ts
+++ b/src/realtime/realtime.gateway.ts
@@ -12,7 +12,7 @@ import {
 import { Server, Socket } from 'socket.io';
 import { TripUpdatesService } from './trip-updates/trip-updates.service';
 import { StationsService } from './stations/stations.service';
-import { Intervals } from 'src/constants';
+import { Intervals } from 'constants/';
 import { AlertsService } from './alerts/alerts.service';
 
 @WebSocketGateway({ cors: true })

--- a/src/realtime/realtime.module.ts
+++ b/src/realtime/realtime.module.ts
@@ -2,8 +2,8 @@ import { Module, CacheModule, CacheModuleOptions } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HttpModule } from '@nestjs/axios';
-import { Stops } from 'src/entities/stops.entity';
-import { Transfers } from 'src/entities/transfers.entity';
+import { Stops } from 'entities/stops.entity';
+import { Transfers } from 'entities/transfers.entity';
 import { RealtimeGateway } from './realtime.gateway';
 import { TripUpdatesService } from './trip-updates/trip-updates.service';
 import { StationsService } from './stations/stations.service';
@@ -11,7 +11,7 @@ import * as redisStore from 'cache-manager-redis-store';
 import { ScheduleModule } from '@nestjs/schedule';
 import { FeedService } from './feed/feed.service';
 import { AlertsService } from './alerts/alerts.service';
-import { CacheTtlSeconds } from 'src/constants';
+import { CacheTtlSeconds } from 'constants/';
 import { RealtimeController } from './realtime.controller';
 
 @Module({

--- a/src/realtime/stations/stations.service.spec.ts
+++ b/src/realtime/stations/stations.service.spec.ts
@@ -1,12 +1,34 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/common';
 import { StationsService } from './stations.service';
+import { Stops } from 'entities/stops.entity';
+import { Transfers } from 'entities/transfers.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('StationsService', () => {
   let service: StationsService;
 
+  const mockStopsRepository = {};
+  const mockTransfersRepository = {};
+  const mockCacheManager = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [StationsService],
+      providers: [
+        StationsService,
+        {
+          provide: getRepositoryToken(Stops),
+          useValue: mockStopsRepository,
+        },
+        {
+          provide: getRepositoryToken(Transfers),
+          useValue: mockTransfersRepository,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+      ],
     }).compile();
 
     service = module.get<StationsService>(StationsService);

--- a/src/realtime/stations/stations.service.ts
+++ b/src/realtime/stations/stations.service.ts
@@ -1,11 +1,11 @@
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
 import { Repository, getManager } from 'typeorm';
-import { Stops } from 'src/entities/stops.entity';
-import { Transfers } from 'src/entities/transfers.entity';
+import { Stops } from 'entities/stops.entity';
+import { Transfers } from 'entities/transfers.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cache } from 'cache-manager';
-import { formatCacheKey, getCurrentDay } from 'src/util';
-import { CacheKeyPrefix, CacheTtlSeconds } from 'src/constants';
+import { formatCacheKey, getCurrentDay } from 'util/';
+import { CacheKeyPrefix, CacheTtlSeconds } from 'constants/';
 import { IIndexedStops, ITransfers } from '../interfaces/stations.interface';
 
 type IndexedStops = {

--- a/src/realtime/trip-updates/trip-updates.service.spec.ts
+++ b/src/realtime/trip-updates/trip-updates.service.spec.ts
@@ -1,12 +1,39 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { TripUpdatesService } from './trip-updates.service';
+import { StationsService } from '../stations/stations.service';
+import { FeedService } from '../feed/feed.service';
 
 describe('TripUpdatesService', () => {
   let service: TripUpdatesService;
 
+  const mockStationsService = {};
+  const mockFeedService = {};
+  const mockConfigService = {};
+  const mockCacheManager = {};
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TripUpdatesService],
+      providers: [
+        TripUpdatesService,
+        {
+          provide: StationsService,
+          useValue: mockStationsService,
+        },
+        {
+          provide: FeedService,
+          useValue: mockFeedService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: mockCacheManager,
+        },
+      ],
     }).compile();
 
     service = module.get<TripUpdatesService>(TripUpdatesService);

--- a/src/realtime/trip-updates/trip-updates.service.ts
+++ b/src/realtime/trip-updates/trip-updates.service.ts
@@ -4,11 +4,11 @@ import { ConfigService } from '@nestjs/config';
 import { Cache } from 'cache-manager';
 import { DateTime } from 'luxon';
 import { StationsService } from '../stations/stations.service';
-import { CacheKeyPrefix, CacheTtlSeconds } from 'src/constants';
 import { FeedService } from '../feed/feed.service';
 import { IIndexedStops } from '../interfaces/stations.interface';
-import { getConfigByFeedIndex } from 'src/util';
 import { IEndpoint } from '../interfaces/trip-updates.interface';
+import { CacheKeyPrefix, CacheTtlSeconds } from 'constants/';
+import { getConfigByFeedIndex } from 'util/';
 
 const MAX_MINUTES = 60;
 

--- a/src/realtime/trip-updates/trip-updates.service.ts
+++ b/src/realtime/trip-updates/trip-updates.service.ts
@@ -1,16 +1,13 @@
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-//import { HttpService } from '@nestjs/axios';
 import { Cache } from 'cache-manager';
 import { DateTime } from 'luxon';
 import { StationsService } from '../stations/stations.service';
 import { FeedService } from '../feed/feed.service';
 import { IIndexedStops } from '../interfaces/stations.interface';
 import { IEndpoint } from '../interfaces/trip-updates.interface';
-import { CacheKeyPrefix, CacheTtlSeconds } from 'constants/';
+import { CacheKeyPrefix, CacheTtlSeconds, MAX_MINUTES } from 'constants/';
 import { getConfigByFeedIndex } from 'util/';
-
-const MAX_MINUTES = 60;
 
 @Injectable()
 export class TripUpdatesService {
@@ -18,9 +15,6 @@ export class TripUpdatesService {
     @Inject(CACHE_MANAGER)
     private readonly cacheManager: Cache,
     private readonly stationsService: StationsService,
-    // TODO: Is it worth utilizing HttpService?
-    // NOTE: This would return an Observable and change the implementation
-    //private readonly http: HttpService,
     private readonly feedService: FeedService,
     private readonly configService: ConfigService,
   ) {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": "./src",
     "incremental": true,
     "skipLibCheck": true
   }


### PR DESCRIPTION
This PR prepares the unit tests for all controllers and services. Currently, GTFS Agency, Feed, and Location controllers/services are covered. This PR fixed the configuration for Jest, and all tests are passing, though not all are fully implemented. This will come in a future PR, along with Swagger documentation. This PR has become quite large, so it will be merged and tests will be added incrementally.